### PR TITLE
Corrige algunos errores tipográficos

### DIFF
--- a/Contenido/03.DocumentoBasico.tex
+++ b/Contenido/03.DocumentoBasico.tex
@@ -14,7 +14,7 @@ Un documento escrito en LaTeX tiene esta pinta\footnote{Este ejemplo
 
 \documentclass[a4paper,10pt]{article}
 
-% PREÁMBULO 
+% PREÁMBULO
 
 % Paquetes
 
@@ -40,7 +40,7 @@ Un documento escrito en LaTeX tiene esta pinta\footnote{Este ejemplo
 \maketitle
 
 \begin{abstract}
-Este documento es una pequeña guía de Python 
+Este documento es una pequeña guía de Python
 \end{abstract}
 
 \tableofcontents
@@ -52,7 +52,7 @@ Este documento es una pequeña guía de Python
     \item Indentación obligatoria
     \item Distingue mayúsculas - minúsculas
     \item No hay declaración de variables (\textit{dynamic typing})
-    \item Orientado a objetos  
+    \item Orientado a objetos
     \item Garbage colector: quita los objetos a los que no haga referencia nada
 \end{itemize}
 
@@ -250,7 +250,7 @@ Quedará así:
 
 \subsection{Imágenes}\label{imuxe1genes}
 
-Hoy solo vamos a ver como colocar una única imagen, que lo de las
+Hoy solo vamos a ver cómo colocar una única imagen, que lo de las
 imágenes tiene un poco de lío. Lo que debemos saber es lo siguiente:
 
 \begin{itemize}

--- a/Contenido/04.Figuras.tex
+++ b/Contenido/04.Figuras.tex
@@ -3,7 +3,7 @@ Decíamos que para insertar figuras nos hacían falta dos cosas:
 \begin{itemize}
 \item
   El paquete
-  \href{https://ctan.org/pkg/graphicx}{\lstinline!graphicx!}, que sustituye al paquete 
+  \href{https://ctan.org/pkg/graphicx}{\lstinline!graphicx!}, que sustituye al paquete
   \lstinline!graphics! y los ayuda a la hora de meter las imágenes y compilar.
 \item
   El comando \lstinline!\includegraphics[opciones]{ruta}!. Aprovechamos
@@ -19,7 +19,7 @@ insertar una figura formada por subfiguras.
 Añadir una figura es superfácil. Solo tenemos que hacer:
 
 \begin{lstlisting}[language={[latex]tex}]
-\includegraphics{ruta_a_la_figura} 
+\includegraphics{ruta_a_la_figura}
 \end{lstlisting}
 
 No hace falta ni siquiera que le pongamos la extensión, él buscará la
@@ -173,7 +173,7 @@ comando \lstinline!\ref{etiqueta}!, por ejemplo:
 Como se ve en la Figura \ref{fig:gatos}, hay gatos negros y blancos
 \end{lstlisting}
 
-LaTeX nos numerará las figuras correctamente el solito y citará la
+LaTeX nos numerará las figuras correctamente él solito y citará la
 figura correspondiente cuando se lo pidamos. Una idea inteligente es
 etiquetar las cosas de manera que luego no nos volvamos locos porque no
 sabemos si una determinada etiqueta hace referencia a una ecuación, a
@@ -280,7 +280,7 @@ debajo. Ahí en medio también podemos decirle cómo de separadas queremos
 las figuras, pero para eso necesitamos aprender primero cómo funciona el
 espacio blanco en LaTeX y eso es tema para otro día. De momento tenéis
 referencias y manuales enlazados para que cambiéis las opciones porque,
-ya sabéis, que si hurgar no se aprende. ¡Espero vuestros comentarios!
+ya sabéis, que sin hurgar no se aprende. ¡Espero vuestros comentarios!
 
 \section{Referencias}\label{referencias4}
 

--- a/Contenido/05.Ecuaciones.tex
+++ b/Contenido/05.Ecuaciones.tex
@@ -148,10 +148,10 @@ ejemplo:
 \sin^2 x + \cos^2 x = 1
 \end{lstlisting}
 
-Que crea: 
+Que crea:
 
 \begin{equation*}
-\sin^2 x + \cos^2 x = 1 
+\sin^2 x + \cos^2 x = 1
 \end{equation*}
 
 \subsection{Matrices}\label{sec:matrices}
@@ -210,8 +210,8 @@ matriz anterior con corchetes tendríamos que hacer lo siguiente:
 \section{Gestión del espacio}\label{sec:espacio}
 
 Al igual que con el texto, LaTeX nos gestiona el espacio entre los
-símbolos él solito. En general lo mejor es dejarle hacer, pero hay en
-ocasiones en hay cosas que quedan \emph{feas} y hay que tocarlas un
+símbolos él solito. En general lo mejor es dejarle hacer, pero en
+ocasiones hay cosas que quedan \emph{feas} y hay que tocarlas un
 poquito a mano. Los nazis del LaTeX nos dirán que no hay que hacer estas
 cosas, que las decisiones de LaTeX deben ser respetadas. Yo no estoy de
 acuerdo, la cuestión es que las ecuaciones queden a nuestro gusto. Para
@@ -253,7 +253,7 @@ Como vemos en la Ecuación \ref{eq:euler}
 
 Que nos daría este resultado:
 
-\begin{equation*} 
+\begin{equation*}
   e^{i\pi} + 1 = 0
 \end{equation*}
 

--- a/Contenido/09.Espacio.tex
+++ b/Contenido/09.Espacio.tex
@@ -81,7 +81,7 @@ ponga siempre el espacio con la versión con asterisco
 % Diferencia entre \hspace y \hspace*
 \hspace{1em}Línea alineada
 
-\hspace*{1em}Línea movida 1 em hacia dentro 
+\hspace*{1em}Línea movida 1 em hacia dentro
 \end{lstlisting}
 
 Un comando similar a \lstinline!\hspace{}! es \lstinline!\phantom{}!,
@@ -148,7 +148,7 @@ a ser posible sin abusar.
 
 \section{Saltos de página}
 
-Lo último que nos queda son los saltos de página. En general uno de
+Lo último que nos queda son los saltos de página. En general uno se
 puede despreocupar porque LaTeX tiene la habilidad de situar las cosas
 más o menos correctamente en la página. En mi opinión saber saltar de
 página es necesario en tres contextos:

--- a/Contenido/10.DocumentoCientifico.tex
+++ b/Contenido/10.DocumentoCientifico.tex
@@ -15,11 +15,11 @@ contenido al principio y se separa el trabajo adicional en apéndices.
 Todo esto implica diferentes formatos para las partes (numeración de las
 páginas y secciones, estilo de los encabezados\ldots{}) y cierta
 planificación. Sin planificar se puede uno volver completamente tarumba,
-lo digo conocimiento de causa, el control de versiones me salvó más de
+lo digo con conocimiento de causa, el control de versiones me salvó más de
 una vez de romper la tesis sin remedio.
 
 Es por ello que primero veremos cómo organizar el documento en cuestión
-y luego haremos un índice, un glosario y hasta unas lista de
+y luego haremos un índice, un glosario y hasta una lista de
 referencias.
 
 \section{División del documento}
@@ -140,7 +140,7 @@ Vamos a ver un ejemplo de uso para entenderlo mejor:
 
   % Cargamos el preámbulo que tenemos escrito en otro archivo
   \input{preámbulo}
-  
+
   % Elegimos qué capítulos queremos que se compilen
   \includeonly{cap1,cap3} % sin espacios!
 
@@ -152,7 +152,7 @@ Vamos a ver un ejemplo de uso para entenderlo mejor:
   % Cargamos los capítulos desde la carpeta Contenido.
   % Los capítulos capX.tex no llevan ni preámbulo ni definición del
   % documento, solo órdenes que irían tras \begin{document}
-  
+
   \include{Contenido/cap1} % cargamos cap1.tex
   \include{Contenido/cap2} % cap2 no aparecerá en el resultado
   \include{Contenido/cap3} % mantiene la numeración como si cap2.tex estuviera incluido
@@ -528,9 +528,9 @@ En definitiva, necesitamos estas dos líneas:
 
 \begin{lstlisting}[language={[latex]tex}]
 % Definimos el estilo bibliográfico
-\bibliographystyle{plain} 
+\bibliographystyle{plain}
 
-% Creamos bibliografía a partir de referencias.bib 
+% Creamos bibliografía a partir de referencias.bib
 \bibliography{referencias}
 \end{lstlisting}
 
@@ -616,7 +616,7 @@ están las referencias.
 
 \section{Referencias}\label{referencias}
 
-\href{http://texblog.org/2007/07/09/documentclassbook-report-article-or-letter/}{\emph{\lstinline!\\documentclass\{book, report, 
+\href{http://texblog.org/2007/07/09/documentclassbook-report-article-or-letter/}{\emph{\lstinline!\\documentclass\{book, report,
 article or letter\}!} en texblog}
 
 \href{http://tex.stackexchange.com/questions/36988/regarding-the-book-report-and-article-document-classes-what-are-the-mai\#36989}{\emph{Regarding

--- a/Contenido/11.Codigo.tex
+++ b/Contenido/11.Codigo.tex
@@ -80,7 +80,7 @@ hacíamos con las tablas y las figuras.
 
 Pasemos ahora a personalizarlo. Si no especificamos nada,
 \lstinline!listings! nos pintará los comentarios en cursiva, las
-palabras claves en negrita y demás, pero todo ello en blanco y negro. Si
+palabras clave en negrita y demás, pero todo ello en blanco y negro. Si
 queremos otro tipo de formato o usar diferentes colores necesitamos
 indicárselo. Veamos cómo se hace.
 

--- a/Contenido/15.Pandoc.tex
+++ b/Contenido/15.Pandoc.tex
@@ -202,7 +202,7 @@ Tabla
 ------------
   x      y
 ----- ------
- 0.1   1.3 
+ 0.1   1.3
 ------------
 
 Table: Aquí va el pie de tabla
@@ -215,7 +215,8 @@ $$Ecuación con línea propia$$
 
 Bloque de código
 
-```haskell
+```
+haskell
 -- Fibonacci!
   fib = 0 : 1 : zipWith (+) fib (tail fib)
 ```
@@ -268,7 +269,7 @@ Un bloque YAML real tiene una pinta como esta:
 \begin{lstlisting}
 ---
 # Datos
-title: Título 
+title: Título
 author: Nombre
 lang: es
 
@@ -334,11 +335,11 @@ gente que sabe de ordenadores lo hará mucho mejor}:
 FILES = INPUT_1.md INPUT_2.md
 
 # Creación de pdf
-# - La barra sirve para partir la orden 
+# - La barra sirve para partir la orden
 # - El filtro crossref debe ir antes de citeproc
 # - Opción -N para numerar secciones
 
-all: 
+all:
     pandoc \
     --filter pandoc-crossref \
     --filter pandoc-citeproc \
@@ -354,7 +355,7 @@ clean:
 
 # Por si hay algún archivo que se llame clean
 
-.PHONY: clean 
+.PHONY: clean
 \end{lstlisting}
 
 Ahora solo nos hace falta llamar a \lstinline!make!:


### PR DESCRIPTION
Durante el estudio de la documentación del curso se han encontrado
algunos errores tipográficos que, he considerado, podrían modificarse
en el repositorio original. 
Por alguna razón en los diff aparecen líneas en las que no se observa
diferencia alguna. No sé muy bien por qué ha ocurrido pero 
pueden ignorarse totalmente.