### PR TITLE
Fix: \linewidth no soportado en versiones recientes de TeX Live.

### DIFF
--- a/Contenido/03.DocumentoBasico.tex
+++ b/Contenido/03.DocumentoBasico.tex
@@ -230,7 +230,7 @@ preocupar. Por ejemplo,
 
 Quedará así:
 
-\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
+\begin{center}\rule{0.5\linewidth}{\@wholewidth}\end{center}
 
 \begin{enumerate}
 \item
@@ -246,7 +246,7 @@ Quedará así:
   Tercer ítem
 \end{enumerate}
 
-\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
+\begin{center}\rule{0.5\linewidth}{\@wholewidth}\end{center}
 
 \subsection{Imágenes}\label{imuxe1genes}
 


### PR DESCRIPTION
Más info: https://github.com/jgm/pandoc/issues/5801.
Propongo la solución aparentemente más sencilla.
Funciona con pdflatex y xelatex.